### PR TITLE
Am branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 First Installation
 ```
-cmsrel CMSSW_10_2_3
-cd CMSSW_10_2_3/src
+cmsrel CMSSW_10_2_15
+cd CMSSW_10_2_15/src
 cmsenv
 git cms-init
 
@@ -28,7 +28,7 @@ export PYTHONPATH=$PYTHONPATH:$PWD
 
 After first installation:
 ```
-cd CMSSW_10_2_3/src/HNLsGen
+cd CMSSW_10_2_15/src/HNLsGen
 cmsenv
 export PYTHONPATH=$PYTHONPATH:$PWD 
 ```
@@ -82,7 +82,7 @@ For showering, instead of using the ```GeneratorFilter```, we use the ```Hadroni
 To visualize the decay chain in a tree (printout to screen), using ```vector<reco::genParticles>```
 ```
 cd genLevelAnalysis
-cmsRun test_ParticleTreeDrawer.py maxEvents=1 inputFiles=file:/work/mratti/GEN_HNL/CMSSW_10_2_3/src/HNLsGen/genSimFiles/BPH-test_HardQCDon.root
+cmsRun test_ParticleTreeDrawer.py maxEvents=1 inputFiles=file:/work/mratti/GEN_HNL/CMSSW_10_2_15/src/HNLsGen/genSimFiles/BPH-test_HardQCDon.root
 ```
 
 To get the gen-level ntuples

--- a/cmsDrivers/step3.py
+++ b/cmsDrivers/step3.py
@@ -2,11 +2,10 @@
 # using: 
 # Revision: 1.19 
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
-# with command line options: step2 --filein file:step2.root --fileout file:step3.root --mc --eventcontent AODSIM --runUnscheduled --datatier AODSIM --conditions 102X_upgrade2018_realistic_v15 --step RAW2DIGI,L1Reco,RECO,RECOSIM,EI --procModifiers premix_stage2 --nThreads 8 --era Run2_2018 --python_filename step3.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n -1
+# with command line options: step1 --filein file:step2.root --fileout file:step3.root --mc --eventcontent AODSIM --datatier AODSIM --conditions 102X_upgrade2018_realistic_v15 --step RAW2DIGI,L1Reco,RECO,RECOSIM,EI --nThreads 8 --era Run2_2018,bParking --python_filename step3.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n -1
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.StandardSequences.Eras import eras
-from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 
 from FWCore.ParameterSet.VarParsing import VarParsing
 
@@ -29,7 +28,7 @@ options.register('inputFile',
 options.outputFile = 'BPH-step3.root'
 options.parseArguments()
 
-process = cms.Process('RECO',eras.Run2_2018,premix_stage2)
+process = cms.Process('RECO',eras.Run2_2018,eras.bParking)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -63,7 +62,7 @@ process.options = cms.untracked.PSet(
 
 # Production Info
 process.configurationMetadata = cms.untracked.PSet(
-    annotation = cms.untracked.string('step2 nevts:-1'),
+    annotation = cms.untracked.string('step1 nevts:-1'),
     name = cms.untracked.string('Applications'),
     version = cms.untracked.string('$Revision: 1.19 $')
 )
@@ -115,10 +114,6 @@ from Configuration.DataProcessing.Utils import addMonitoring
 process = addMonitoring(process)
 
 # End of customisation functions
-#do not add changes to your config after this point (unless you know what you are doing)
-from FWCore.ParameterSet.Utilities import convertToUnscheduled
-process=convertToUnscheduled(process)
-
 
 # Customisation from command line
 process.MessageLogger.cerr.FwkReport.reportEvery=1000

--- a/cmsDrivers/step4.py
+++ b/cmsDrivers/step4.py
@@ -2,7 +2,7 @@
 # using: 
 # Revision: 1.19 
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
-# with command line options: step1 --filein file:step3.root --fileout file:step4.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 102X_upgrade2018_realistic_v15 --step PAT --nThreads 8 --geometry DB:Extended --era Run2_2018 --python_filename step4.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n -1
+# with command line options: step1 --filein file:step3.root --fileout file:step4.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 102X_upgrade2018_realistic_v15 --step PAT --nThreads 8 --geometry DB:Extended --era Run2_2018,bParking --python_filename step4.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n -1
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.StandardSequences.Eras import eras
@@ -28,7 +28,7 @@ options.register('inputFile',
 options.outputFile = 'BPH-step4.root'
 options.parseArguments()
 
-process = cms.Process('PAT',eras.Run2_2018)
+process = cms.Process('PAT',eras.Run2_2018,eras.bParking)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -76,7 +76,6 @@ process.MINIAODSIMoutput = cms.OutputModule("PoolOutputModule",
     dropMetaData = cms.untracked.string('ALL'),
     eventAutoFlushCompressedSize = cms.untracked.int32(-900),
     fastCloning = cms.untracked.bool(False),
-    #fileName = cms.untracked.string('file:{}'.format(options.outputFile)),
     fileName = cms.untracked.string(options.outputFile),
     outputCommands = process.MINIAODSIMEventContent.outputCommands,
     overrideBranchesSplitLevel = cms.untracked.VPSet(

--- a/python/decays.py
+++ b/python/decays.py
@@ -1,6 +1,6 @@
 '''
-This script collects the particle definition and creates the ProductionRates class, that lists
-the production rates of interest, with respect to the HNL mass and the mixing angle
+This script collects the particle definition and creates the Decays class, that contains
+the B->HNL branching ratios of interest, as a function of HNL mass and the mixing angle
 '''
 
 from objects import Particle, Decay

--- a/slurm/prodHelper.py
+++ b/slurm/prodHelper.py
@@ -404,7 +404,7 @@ def getOptions():
   parser.add_argument('-v','--ver', type=str, dest='ver', help='version of production, e.g. V00_v00', default='V00_v00')
   parser.add_argument('-n','--nevts', type=int, dest='nevts', help='total number of events to be generated', default=10)
   parser.add_argument('--time', type=str, dest='time', help='allowed time for each job', default='08')
-  parser.add_argument('--mem', type=str, dest='mem', help='allowed memory for each job in [MB]', default='2500')
+  parser.add_argument('--mem', type=str, dest='mem', help='allowed memory for each job in [MB]', default='3500')
   parser.add_argument('--njobs', type=int, dest='njobs', help='number of parallel jobs to submit', default=10)
   parser.add_argument('--points', type=str, dest='pointFile', help='name of file contaning information on scan to be run', default='points.py')
   parser.add_argument('--domultithread', dest='domultithread', help='run multithreaded', action='store_true', default=False)

--- a/slurm/prodHelper.py
+++ b/slurm/prodHelper.py
@@ -22,7 +22,6 @@ class Job(object):
     self.nevtsjob = self.nevts if not self.domultijob else self.nevts/self.njobs
     self.prodLabel = '{v}_n{n}_njt{nj}'.format(v=self.ver,n=self.nevts,nj=self.njobs)
     self.nthr = 8 if self.domultithread else 1
-    self.npremixfiles = 20 # the number of events per file being 1200
     self.user = os.environ["USER"]
     self.jop1_in = 'step1.py' if not self.dobc else 'step1_Bc.py'
     self.jop1 = 'step1.py'
@@ -202,14 +201,14 @@ class Job(object):
       print('===> Created evtGen decay files\n')
 
 
-  def appendTemplate(self, jopa, jopb, nthr, nevtsjob, npremixfiles=0):
+  def appendTemplate(self, jopa, jopb, nthr, nevtsjob):
     if self.dogenonly:
       addlines = ''
     else:
       labela = jopa[0:len(jopa)-3]
       labelb = jopb[0:len(jopb)-3]
       if jopa == 'step2.py':
-        command = 'cmsRun {jopa} randomizePremix=1 nPremixFiles={nprx} nThr={nthr} inputFile=BPH-{lblb}_numEvent{nevtsjob}.root outputFile=BPH-{lbla}.root seedOffset=$SLURM_ARRAY_TASK_ID'.format(jopa=jopa, nprx=npremixfiles, nthr=nthr, lblb=labelb, nevtsjob=nevtsjob, lbla=labela)
+        command = 'cmsRun {jopa} randomizePremix=1 nPremixFiles={nprx} nThr={nthr} inputFile=BPH-{lblb}_numEvent{nevtsjob}.root outputFile=BPH-{lbla}.root seedOffset=$SLURM_ARRAY_TASK_ID'.format(jopa=jopa, nprx=self.npremixfiles, nthr=nthr, lblb=labelb, nevtsjob=nevtsjob, lbla=labela)
       else:
         command = 'cmsRun {jopa} nThr={nthr} inputFile=BPH-{lblb}.root outputFile=BPH-{lbla}.root seedOffset=$SLURM_ARRAY_TASK_ID'.format(jopa=jopa, nthr=1, lblb=labelb, lbla=labela)
 
@@ -361,7 +360,7 @@ class Job(object):
           jop2=self.jop2,
           jop3=self.jop3,
           jop4=self.jop4,
-          addstep2=self.appendTemplate(self.jop2,self.jop1,self.nthr,self.nevtsjob,self.npremixfiles),
+          addstep2=self.appendTemplate(self.jop2,self.jop1,self.nthr,self.nevtsjob),
           addstep3=self.appendTemplate(self.jop3,self.jop2,self.nthr,self.nevtsjob),
           addstep4=self.appendTemplate(self.jop4,self.jop3,self.nthr,self.nevtsjob),
           timestamp=self.makeTimeStamp()
@@ -407,6 +406,7 @@ def getOptions():
   parser.add_argument('--mem', type=str, dest='mem', help='allowed memory for each job in [MB]', default='3500')
   parser.add_argument('--njobs', type=int, dest='njobs', help='number of parallel jobs to submit', default=10)
   parser.add_argument('--points', type=str, dest='pointFile', help='name of file contaning information on scan to be run', default='points.py')
+  parser.add_argument('--npremixfiles', type=str, dest='npremixfiles', help='number of premixing files to be randomly chosen', default=3)
   parser.add_argument('--domultithread', dest='domultithread', help='run multithreaded', action='store_true', default=False)
   parser.add_argument('--domultijob', dest='domultijob', help='run several separate jobs', action='store_true', default=False)
   parser.add_argument('--dosubmit', dest='dosubmit', help='submit to slurm', action='store_true', default=False)


### PR DESCRIPTION
@mgratti 

In this PR:
- adaptation of the cmsdrivers (step2->step4) to the bparking conditions
- default mem/job increased in the prodHelper
- option to set the number of premixing files added (default set to 3, with 25k events per file)

Make sure to move to the 10_2_15 release, as the updated cmsDrivers are not compatible with 10_2_3